### PR TITLE
fix: deprecated null to string conversion

### DIFF
--- a/src/UtmCookie/UtmCookie.php
+++ b/src/UtmCookie/UtmCookie.php
@@ -351,7 +351,7 @@ class UtmCookie
 		
 		foreach ($utmCookieSave as $key => $value) {
 			if (true === in_array($key, self::$allowedUtmCookieKeys, false)) {
-				setcookie(self::$utmCookieName . '[' . $key . ']', $value, $expire->getTimestamp(), self::$path, self::$domain, self::$secure, self::$httpOnly);
+				setcookie(self::$utmCookieName . '[' . $key . ']', strval($value), $expire->getTimestamp(), self::$path, self::$domain, self::$secure, self::$httpOnly);
 			}
 		}
 


### PR DESCRIPTION
fix: deprecated null to string conversion

In php 8, null to string conversion causes deprecated notice.

```sh
Deprecated: setcookie(): Passing null to parameter #2 ($value) of type string is deprecated
```